### PR TITLE
Correct the date format for the barcode service call

### DIFF
--- a/src/classes/FormsApiClient.cls
+++ b/src/classes/FormsApiClient.cls
@@ -334,21 +334,10 @@ public with sharing class FormsApiClient {
 
     //Barcode body
     public String getBarcodeBody() {
-        String month;
+        Datetime dt = Datetime.now();
+        String formattedDate = dt.format('YYYYMMdd');
 
-        Date d = System.today();
-
-
-        if (d.month() < 10)
-            month = '0' + String.valueOf(d.month());
-        else
-            month = String.valueOf(d.month());
-
-
-        //e.g. '20160413';
-        String dateString = String.valueOf(d.year()) + month + String.valueOf(d.day());
-
-        return '{"datereceived":' + dateString + '}';
+        return '{"datereceived":' + formattedDate + '}';
     }
 
     // Aux for Authentication

--- a/src/classes/FormsApiClientTest.cls
+++ b/src/classes/FormsApiClientTest.cls
@@ -90,6 +90,22 @@ public with sharing class FormsApiClientTest {
         
         Test.stopTest();
     }
+    
+        
+    @isTest(seeAllData=false)
+    public static void getBarcodeBodyTest() {
+
+        Test.startTest();
+
+        FormsApiClient client = new FormsApiClient();
+        String barcodeBody = client.getBarcodeBody();
+        List<String> bodyParts = barcodeBody.split(':');
+        System.assertEquals('{"datereceived"', bodyParts.get(0));
+        System.assertEquals(9, bodyParts.get(1).length());
+        System.assertEquals(true, bodyParts.get(1).left(8).isNumeric());
+        
+        Test.stopTest();
+    }
 
     @isTest(seeAllData=false)
     public static void getJsonPackageNoPresenterTest() {


### PR DESCRIPTION
Ensure that the date format used for the barcode service call is 8 characters - i.e. 20181203 instead of 2018123